### PR TITLE
fixes issue where api returning None causes loader to crash

### DIFF
--- a/src/flair_loader/skin_loader.py
+++ b/src/flair_loader/skin_loader.py
@@ -137,7 +137,7 @@ class Loader:
                                     "enabled": False
                                 }
                                 cprint(f"[{skin['displayName']}] found new level data ({level['displayName']})","cyan")
-                        if level["displayName"] == skin["displayName"].replace("Standard ",""):
+                        if level is not None and level["displayName"] == skin["displayName"].replace("Standard ",""):
                             # if skin is standard
                             process_skin_level()
                         else:


### PR DESCRIPTION
Found an issue where the API would return two POLYFOX Judge levels, where it should only have one. The second level is just a NoneType, so to prevent any issues like this in the future, I added this bit of code. Hopefully it doesn't break anything.